### PR TITLE
More fixes

### DIFF
--- a/src/ThrowAssert.hpp
+++ b/src/ThrowAssert.hpp
@@ -1,0 +1,117 @@
+#include <exception>
+#include <string>
+#include <sstream>
+#include <iostream>
+
+/// Exception type for assertion failures
+class AssertionFailureException : public std::exception
+{
+private:
+  const char* expression;
+  const char* file;
+  int line;
+  std::string message;
+  std::string report;
+
+public:
+
+  /// Helper class for formatting assertion message
+  class StreamFormatter
+  {
+  private:
+
+    std::ostringstream stream;
+
+  public:
+
+    operator std::string() const
+    {
+      return stream.str();
+    }
+
+    template<typename T>
+    StreamFormatter& operator << (const T& value)
+    {
+      stream << value;
+      return *this;
+    }
+  };
+
+  /// Log error before throwing
+  void LogError()
+  {
+#ifdef THROWASSERT_LOGGER
+    THROWASSERT_LOGGER(report);
+#else
+    std::cerr << report << std::endl;
+#endif
+  }
+
+  /// Construct an assertion failure exception
+  AssertionFailureException(const char* expression, const char* file, int line, const std::string& message)
+    : expression(expression)
+    , file(file)
+    , line(line)
+    , message(message)
+  {
+    std::ostringstream outputStream;
+
+    if (!message.empty())
+      {
+        outputStream << message << ": ";
+      }
+
+    std::string expressionString = expression;
+
+    if (expressionString == "false" || expressionString == "0" || expressionString == "FALSE")
+      {
+        outputStream << "Unreachable code assertion";
+      }
+    else
+      {
+        outputStream << "Assertion '" << expression << "'";
+      }
+
+    outputStream << " failed in file '" << file << "' line " << line;
+    report = outputStream.str();
+
+    LogError();
+  }
+
+  /// The assertion message
+  virtual const char* what() const throw()
+  {
+    return report.c_str();
+  }
+
+  /// The expression which was asserted to be true
+  const char* Expression() const throw()
+  {
+    return expression;
+  }
+
+  /// Source file
+  const char* File() const throw()
+  {
+    return file;
+  }
+
+  /// Source line
+  int Line() const throw()
+  {
+    return line;
+  }
+
+  /// Description of failure
+  const char* Message() const throw()
+  {
+    return message.c_str();
+  }
+
+  ~AssertionFailureException() throw()
+  {
+  }
+};
+
+/// Assert that EXPRESSION evaluates to true, otherwise raise AssertionFailureException with associated MESSAGE (which may use C++ stream-style message formatting)
+#define throw_assert(EXPRESSION) if(!(EXPRESSION)) { throw AssertionFailureException(#EXPRESSION, __FILE__, __LINE__, (AssertionFailureException::StreamFormatter() << "")); }

--- a/src/ligand.cpp
+++ b/src/ligand.cpp
@@ -101,7 +101,7 @@ void ligand::load_from_path(const path& p)
 				}
 
 				// Save the heavy atom.
-        throw_assert(atoms.size() < 100);
+        throw_assert(atoms.size() < 100); // godel-chem assertion
 				atoms.push_back(move(a));
 			}
 		}
@@ -117,7 +117,7 @@ void ligand::load_from_path(const path& p)
 				if (atoms[i].serial == rotorXsrn)
 				{
 					// Insert a new frame whose parent is the current frame.
-          throw_assert(frames.size() < 30);
+          throw_assert(frames.size() < 30); // godel-chem assertion
 					frames.emplace_back(current, rotorXsrn, rotorYsrn, i, atoms.size());
 					break;
 				}
@@ -207,7 +207,7 @@ void ligand::load_from_path(const path& p)
 	frames.back().childYidx = na = atoms.size();
 	nf = frames.size();
 	throw_assert(nf >= 1 + nv - 6);
-  throw_assert(na > 1);
+  throw_assert(na > 1); // godel-chem assertion
 
 	// Detect the presence of XScore atom types.
 	for (const auto& a : atoms)

--- a/src/ligand.cpp
+++ b/src/ligand.cpp
@@ -41,7 +41,7 @@ void ligand::load_from_path(const path& p)
 			atom a(line);
 
 			// Skip unsupported atom types.
-			if (a.ad_unsupported()) continue;
+      throw_assert(!a.ad_unsupported());
 
 			if (a.is_hydrogen()) // Current atom is a hydrogen.
 			{
@@ -205,6 +205,7 @@ void ligand::load_from_path(const path& p)
 	frames.back().childYidx = na = atoms.size();
 	nf = frames.size();
 	throw_assert(nf >= 1 + nv - 6);
+  throw_assert(na > 1);
 
 	// Detect the presence of XScore atom types.
 	for (const auto& a : atoms)

--- a/src/ligand.cpp
+++ b/src/ligand.cpp
@@ -13,8 +13,6 @@ ligand::ligand(const path& p) : filename(p.filename()), xs{}, nv(6) {}
 
 void ligand::load_from_path(const path& p)
 {
-	cout << "parsing ligand " << p.filename() << endl;
-
 	// Initialize necessary variables for constructing a ligand.
 	frames.reserve(30); // A ligand typically consists of <= 30 frames.
 	frames.emplace_back(0, 0, 0, 0, 0); // ROOT is also treated as a frame. The parent, rotorXsrn, rotorYsrn, rotorXidx of ROOT frame are dummy.

--- a/src/ligand.cpp
+++ b/src/ligand.cpp
@@ -9,7 +9,9 @@ void frame::output(boost::filesystem::ofstream& ofs) const
 	ofs << "BRANCH"    << setw(4) << rotorXsrn << setw(4) << rotorYsrn << '\n';
 }
 
-ligand::ligand(const path& p) : filename(p.filename()), xs{}, nv(6)
+ligand::ligand(const path& p) : filename(p.filename()), xs{}, nv(6) {}
+
+void ligand::load_from_path(const path& p)
 {
 	cout << "parsing ligand " << p.filename() << endl;
 

--- a/src/ligand.cpp
+++ b/src/ligand.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <iomanip>
 #include <numeric>
 #include "array.hpp"
@@ -10,6 +11,8 @@ void frame::output(boost::filesystem::ofstream& ofs) const
 
 ligand::ligand(const path& p) : filename(p.filename()), xs{}, nv(6)
 {
+	cout << "parsing ligand " << p.filename() << endl;
+
 	// Initialize necessary variables for constructing a ligand.
 	frames.reserve(30); // A ligand typically consists of <= 30 frames.
 	frames.emplace_back(0, 0, 0, 0, 0); // ROOT is also treated as a frame. The parent, rotorXsrn, rotorYsrn, rotorXidx of ROOT frame are dummy.

--- a/src/ligand.cpp
+++ b/src/ligand.cpp
@@ -101,6 +101,7 @@ void ligand::load_from_path(const path& p)
 				}
 
 				// Save the heavy atom.
+        throw_assert(atoms.size() < 100);
 				atoms.push_back(move(a));
 			}
 		}
@@ -116,6 +117,7 @@ void ligand::load_from_path(const path& p)
 				if (atoms[i].serial == rotorXsrn)
 				{
 					// Insert a new frame whose parent is the current frame.
+          throw_assert(frames.size() < 30);
 					frames.emplace_back(current, rotorXsrn, rotorYsrn, i, atoms.size());
 					break;
 				}

--- a/src/ligand.hpp
+++ b/src/ligand.hpp
@@ -62,6 +62,8 @@ public:
 
 	//! Gets the number of elements of a conformation.
 	size_t get_cnf_elems() const;
+
+	void load_from_path(const path& p);
 private:
 	//! Represents a pair of interacting atoms that are separated by 3 consecutive covalent bonds.
 	class interacting_pair

--- a/src/main_cu.cpp
+++ b/src/main_cu.cpp
@@ -392,14 +392,22 @@ int main(int argc, char* argv[])
 	     << "   Index        Ligand D  pKd 1     2     3     4     5     6     7     8     9" << endl << setprecision(2);
 	for (directory_iterator dir_iter(input_folder_path), const_dir_iter; dir_iter != const_dir_iter; ++dir_iter)
 	{
-		try {
-
     // Filter files with .pdbqt extension name.
 		const path& input_ligand_path = dir_iter->path();
 		if (input_ligand_path.extension() != ".pdbqt") continue;
 
-    // Parse the ligand. Don't declare it const as it will be moved to the callback data wrapper.
-		ligand lig(input_ligand_path);
+    cout << "Loading ligand: " << input_ligand_path.filename() << endl;
+
+    ligand lig(input_ligand_path);
+
+    try {
+      // Parse the ligand. Don't declare it const as it will be moved to the callback data wrapper.
+      lig.load_from_path(input_ligand_path);
+    } catch (const exception& e) {
+      cerr << "Error loading ligand: " << input_ligand_path.filename() << endl;
+      cerr << e.what() << endl;
+      continue;
+    }
 
 		// Find atom types that are presented in the current ligand but not presented in the grid maps.
 		vector<size_t> xs;
@@ -537,11 +545,6 @@ int main(int argc, char* argv[])
 
 		// Pop the context after use.
 		checkCudaErrors(cuCtxPopCurrent(NULL));
-
-    } catch (const exception& e) {
-      cerr << e.what() << endl;
-      continue;
-    }
 	}
 
 	// Synchronize contexts.

--- a/src/main_cu.cpp
+++ b/src/main_cu.cpp
@@ -409,7 +409,7 @@ int main(int argc, char* argv[])
 
       // Save the result with the affinities as 0
       string stem = input_ligand_path.filename().stem().string();
-      lig.affinities = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+      lig.affinities = vector<float>(max_conformations);
       log.push_back(new log_record(move(stem), move(lig.affinities)));
       continue;
     }
@@ -484,7 +484,7 @@ int main(int argc, char* argv[])
 
       // Save the result with the affinities as 0
       string stem = input_ligand_path.filename().stem().string();
-      lig.affinities = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+      lig.affinities = vector<float>(max_conformations);
       log.push_back(new log_record(move(stem), move(lig.affinities)));
       continue;
     }

--- a/src/main_cu.cpp
+++ b/src/main_cu.cpp
@@ -406,6 +406,10 @@ int main(int argc, char* argv[])
     } catch (const exception& e) {
       cerr << "Error loading ligand: " << input_ligand_path.filename() << endl;
       cerr << e.what() << endl;
+
+      // Save the result with the affinities as 0
+      string stem = input_ligand_path.filename().string();
+      log.push_back(new log_record(move(stem), move(lig.affinities)));
       continue;
     }
 

--- a/src/main_cu.cpp
+++ b/src/main_cu.cpp
@@ -408,8 +408,9 @@ int main(int argc, char* argv[])
       cerr << e.what() << endl;
 
       // Save the result with the affinities as 0
-      string stem = input_ligand_path.filename().string();
-      // log.push_back(new log_record(move(stem), move(lig.affinities)));
+      string stem = input_ligand_path.filename().stem().string();
+      lig.affinities = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+      log.push_back(new log_record(move(stem), move(lig.affinities)));
       continue;
     }
 
@@ -482,8 +483,9 @@ int main(int argc, char* argv[])
       cerr << e.what() << endl;
 
       // Save the result with the affinities as 0
-      string stem = input_ligand_path.filename().string();
-      // log.push_back(new log_record(move(stem), move(lig.affinities)));
+      string stem = input_ligand_path.filename().stem().string();
+      lig.affinities = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+      log.push_back(new log_record(move(stem), move(lig.affinities)));
       continue;
     }
 

--- a/src/main_cu.cpp
+++ b/src/main_cu.cpp
@@ -409,7 +409,7 @@ int main(int argc, char* argv[])
 
       // Save the result with the affinities as 0
       string stem = input_ligand_path.filename().string();
-      log.push_back(new log_record(move(stem), move(lig.affinities)));
+      // log.push_back(new log_record(move(stem), move(lig.affinities)));
       continue;
     }
 
@@ -475,7 +475,17 @@ int main(int argc, char* argv[])
 		const size_t lig_bytes = sizeof(int) * lig_elems[dev];
 
 		// Encode the current ligand.
-		lig.encode(ligh[dev]);
+    try {
+      lig.encode(ligh[dev]);
+    } catch (const exception& e) {
+      cerr << "Error encoding ligand: " << input_ligand_path.filename() << endl;
+      cerr << e.what() << endl;
+
+      // Save the result with the affinities as 0
+      string stem = input_ligand_path.filename().string();
+      // log.push_back(new log_record(move(stem), move(lig.affinities)));
+      continue;
+    }
 
 		// Reallocate slnd should the current solution elements exceed the default size.
 		const size_t this_sln_elems = lig.get_sln_elems();

--- a/src/main_cu.cpp
+++ b/src/main_cu.cpp
@@ -392,11 +392,13 @@ int main(int argc, char* argv[])
 	     << "   Index        Ligand D  pKd 1     2     3     4     5     6     7     8     9" << endl << setprecision(2);
 	for (directory_iterator dir_iter(input_folder_path), const_dir_iter; dir_iter != const_dir_iter; ++dir_iter)
 	{
-		// Filter files with .pdbqt extension name.
+		try {
+
+    // Filter files with .pdbqt extension name.
 		const path& input_ligand_path = dir_iter->path();
 		if (input_ligand_path.extension() != ".pdbqt") continue;
 
-		// Parse the ligand. Don't declare it const as it will be moved to the callback data wrapper.
+    // Parse the ligand. Don't declare it const as it will be moved to the callback data wrapper.
 		ligand lig(input_ligand_path);
 
 		// Find atom types that are presented in the current ligand but not presented in the grid maps.
@@ -535,6 +537,11 @@ int main(int argc, char* argv[])
 
 		// Pop the context after use.
 		checkCudaErrors(cuCtxPopCurrent(NULL));
+
+    } catch (const exception& e) {
+      cerr << e.what() << endl;
+      continue;
+    }
 	}
 
 	// Synchronize contexts.


### PR DESCRIPTION
- Catch all ligand parsing assertion errors and logs them instead of crashing the program
- Adds new assertions to limit the size of the ligand